### PR TITLE
Only import `cortex-m` when needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ categories = [
     "concurrency",
 ]
 
-[dependencies]
+[target.thumbv6m-none-eabi.dependencies]
 cortex-m = "0.7.1"


### PR DESCRIPTION
This allows this crate to be used as a true shim crate if not on `thumbv6` and else it will start pulling in dependencies when on `thumbv6`.
It makes it easier in crates above to include this and not get the `cortex-m` dependency unless when needed, eg `heapless` which targets more than only ARM targets.