### PR TITLE
Add polyfill for Game Boy Advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The right polyfill level is automatically picked based on the target and the ato
 
 | Target             | Level            | Level for u64/i64 |
 |--------------------|------------------|-------------------|
+| thumbv4t           | Full<sup>1</sup> | Full              |
 | thumbv6m           | CAS              | Full              |
 | thumbv7*, thumbv8* | Native           | Full              |
 | riscv32imc         | Full<sup>1</sup> | Full              |

--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,8 @@ fn main() {
         (Full, Full)
     } else if target.starts_with("riscv32") {
         (Native, Full)
+    } else if target.starts_with("thumbv4") {
+        (Full, Full)
     } else if target.starts_with("thumbv6m-") {
         (Cas, Full)
     } else if target.starts_with("thumb") {


### PR DESCRIPTION
At present the system assumes that all Thumb targets other than `thumbv6m-none-eabi` have full support for atomics up to 32-bit, which isn't correct since prior to ARMv6 there was no hardware support for atomics at all. In Rust this primarily affects the bare-metal target `thumbv4t-none-eabi` (which was added for the Game Boy Advance - since we now have `armv6k-nintendo-3ds` it might be due for a rename to something like `armv4t-nintendo-gba`, but according to Lokathor the generic name was actually requested by the rustc developers so who knows) since Linux provides its own userspace support.