### PR TITLE
Add forbid(unsafe_code) for `reexport_core` targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(reexport_core, forbid(unsafe_code))]
 
 #[cfg(reexport_core)]
 pub use core::sync::atomic::*;


### PR DESCRIPTION
Makes me feel better when this crate shows up in `cargo geiger`