### PR TITLE
add force-polyfill feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet
+- Add `force-polyfill` feature to force polyfilling even on targets that have native atomics.
 
 ## 1.0.2 - 2023-03-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ categories = [
 
 [dependencies]
 critical-section = "1.0.0"
+
+[features]
+force-polyfill = []

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The right polyfill level is automatically picked based on the target and the ato
 
 For targets not listed above, `atomic-polyfill` assumes nothing and reexports `core::sync::atomic::*`. No polyfilling is done. PRs for polyfilling more targets are welcome :)
 
+## Forcing polyfill
+
+You can force polyfilling in targets that support atomic operations by setting the `force-polyfill` feature.
+This is useful for targets that do not fully support atomic operations such as load-reserved or store-conditionals.
+
 ## Minimum Supported Rust Version (MSRV)
 
 MSRV is currently **Rust 1.54**. MSRV may be upgraded at any new patch release as long

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,23 @@ fn main() {
 
     use PolyfillLevel::*;
 
+    // If the user explicitly requests a polyfill, we add all the polyfill cfgs and exit.
+    if env::var("CARGO_FEATURE_FORCE_POLYFILL").is_ok() {
+        println!("cargo:rustc-cfg=polyfill_u8");
+        println!("cargo:rustc-cfg=polyfill_u16");
+        println!("cargo:rustc-cfg=polyfill_u32");
+        println!("cargo:rustc-cfg=polyfill_u64");
+        println!("cargo:rustc-cfg=polyfill_usize");
+        println!("cargo:rustc-cfg=polyfill_i8");
+        println!("cargo:rustc-cfg=polyfill_i16");
+        println!("cargo:rustc-cfg=polyfill_i32");
+        println!("cargo:rustc-cfg=polyfill_i64");
+        println!("cargo:rustc-cfg=polyfill_isize");
+        println!("cargo:rustc-cfg=polyfill_ptr");
+        println!("cargo:rustc-cfg=polyfill_bool");
+        return;
+    }
+
     let patterns = [
         ("avr-*", (Polyfill, Polyfill)),
         ("msp430-none-elf", (Polyfill, Polyfill)),

--- a/ci.sh
+++ b/ci.sh
@@ -14,3 +14,18 @@ cargo build --target msp430-none-elf -Zbuild-std=core
 
 # without --release, it fails with "error: ran out of registers during register allocation"
 cargo build --release -Zbuild-std=core --target avr-specs/avr-atmega328p.json
+
+
+# Same as above, but with --features=force-polyfill
+cargo build --features=force-polyfill
+cargo build --target thumbv6m-none-eabi --features=force-polyfill
+cargo build --target thumbv7em-none-eabi --features=force-polyfill
+cargo build --target riscv32imc-unknown-none-elf --features=force-polyfill
+cargo build --target riscv32imac-unknown-none-elf --features=force-polyfill
+cargo build --target i686-unknown-linux-gnu --features=force-polyfill
+cargo build --target x86_64-unknown-linux-gnu --features=force-polyfill
+cargo build --target riscv64gc-unknown-linux-gnu --features=force-polyfill
+cargo build --target msp430-none-elf -Zbuild-std=core --features=force-polyfill
+
+# without --release, it fails with "error: ran out of registers during register allocation"
+cargo build --release -Zbuild-std=core --target avr-specs/avr-atmega328p.json --features=force-polyfill


### PR DESCRIPTION
I'm facing weird situations with a riscv32imac target, so I ended up needing this feature.
Basically, by activating the `force-polyfill` feature, the `build.rs` script skips all the target checking and just uses all the atomic emulations provided by `atomic-polyfill`.

Hope you find it helpful!